### PR TITLE
mediaserverのサンプル設定を用意する

### DIFF
--- a/docs/compose.yml
+++ b/docs/compose.yml
@@ -67,6 +67,28 @@ services:
     networks:
       - internal
 
+#  mediaserver:
+#    image: ghcr.io/totegamma/cc-media-server:latest
+#    restart: always
+#    links:
+#      - db
+#    depends_on:
+#      db:
+#        condition: service_healthy
+#    expose:
+#      - 8000
+#    environment:
+#      bucketName:
+#      endpointUrl:
+#      accessKeyId:
+#      accessKeySecret:
+#      publicBaseUrl:
+#      quota:
+#      forcePathStyle:
+#      db_dsn: "host=db user=postgres password=postgres dbname=concurrent"
+#    networks:
+#      - internal
+
   db:
     restart: always
     image: postgres

--- a/docs/config/gateway.yaml
+++ b/docs/config/gateway.yaml
@@ -25,3 +25,7 @@ services:
     path: /.well-known
     preservePath: true
     injectCors: true
+#  - name: mediaserver
+#    host: mediaserver
+#    port: 8000
+#    path: /storage


### PR DESCRIPTION
docs/compose.yml にmediaserverがバックポートされていないためコメントアウト状態でバックポートします。
加えて、セットアップが大変なので、apbrdigeも当面は標準でコメントアウトで良いかもしれないです。